### PR TITLE
Fix visual tests to run headless

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "release:publish": "react-scripts build && electron-builder build --linux --arm64 --publish always",
     "release:publish:draft": "react-scripts build && electron-builder build --linux --arm64 --publish onTagOrDraft",
     "release:patch:publish": "npm version patch -m \"chore(release): version %s\" && git push --follow-tags && npm run release:publish",
+    "test": "npm run test:visuals",
     "test:visuals": "node scripts/visual-test-runner.js",
     "farm:audio": "node scripts/generative/farm-audio.js",
     "generate:audio": "electron . --generate"

--- a/scripts/visual-test-runner.js
+++ b/scripts/visual-test-runner.js
@@ -8,7 +8,9 @@ console.log('Starting visual effect tests...');
 const electronPath = require('electron');
 const testScript = path.join(__dirname, '../tests/visual-effect-tests.js');
 
-const testProcess = spawn(electronPath, [testScript], {
+// When running in a root environment (e.g. CI containers) Electron requires the
+// --no-sandbox flag. Add it so the tests can run without privileges errors.
+const testProcess = spawn(electronPath, ['--no-sandbox', '--headless', testScript], {
   stdio: 'inherit'
 });
 

--- a/tests/visual-effect-tests.js
+++ b/tests/visual-effect-tests.js
@@ -152,11 +152,12 @@ async function runTests() {
   const window = new BrowserWindow({
     width: 1024,
     height: 768,
-    show: true,  // Show the window while testing
+    show: false,  // run headlessly in CI
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,
       webSecurity: false,
+      offscreen: true,
       additionalArguments: [`--app-path=${app.getAppPath()}`]
     }
   });


### PR DESCRIPTION
## Summary
- adjust visual test runner to use Electron in headless mode
- create BrowserWindow offscreen to avoid needing a display

## Testing
- `npm test --silent`